### PR TITLE
Experiment A

### DIFF
--- a/Dockerfile.prefect
+++ b/Dockerfile.prefect
@@ -1,30 +1,26 @@
-# This image (built via Dockerfile.prefect) is used for the Prefect backend.
-FROM prefecthq/prefect:1.3.1-python3.10 as python-base
+FROM python:3.10-slim as base
 
-RUN apt-get update && apt-get install -y curl
+# tell prefect where to find our package code
+ENV PYTHONPATH=/workdir/
 
-# RUN curl -sL https://install.python-poetry.org | python - -y
+# needed to build psutil on arm64
+RUN apt-get update && apt-get install -y gcc python3-dev git gcc g++ libblas-dev
+# RUN apt-get update && apt-get install -y --no-install-recommends gcc python3-dev git gcc
+
+# python dependencies
+RUN pip install --upgrade pip
 RUN pip install poetry
 
-FROM python-base as builder-base
+FROM base
+RUN poetry config virtualenvs.create false
+RUN poetry config virtualenvs.prefer-active-python true
+RUN poetry config installer.no-binary :all:
 
-COPY pyproject.toml poetry.lock /aid/
+# RUN ls -la /
+# RUN mkdir /workdir/
+# RUN ls -la /workdir/
+WORKDIR /workdir/
 
-ENV APP_HOME /aid/
-WORKDIR $APP_HOME
+COPY . /workdir/
 
-RUN poetry config virtualenvs.create true
-RUN poetry config virtualenvs.in-project true
 RUN poetry install --only main --no-root
-
-FROM builder-base as final-stage
-COPY README.md aid/ /aid/
-RUN poetry install --only main
-
-RUN ls -la /
-RUN ls -la /aid/
-
-# Setup env, assuming repos are mounted correctly at runtime
-ENV PYTHONPATH="$PYTHONPATH:/aid/.venv/"
-# put prefect into the path - should not be needed??
-# ENV PATH="$PATH:/aid"


### PR DESCRIPTION
**Build Results**
* Succeeds: Yes
* Fast? No

**Flows working?**
* `basic-add-flow`: Yes
* `basic-pandas-flow`: No
   * `ModuleNotFoundError: No module named 'numpy'`

**Notable output from build (see full log below):**
* `pip show prefect...Package(s) not found: prefect`
* `The virtual environment found in /workdir/.venv seems to be broken.`

**Full build log:**
```
$ ./aid/prefect/step-3-register-flow.sh
Configuration file exists at /Users/b-long/Library/Application Support/pypoetry, reusing this directory.

Consider moving configuration to /Users/b-long/Library/Preferences/pypoetry, as support for the legacy directory will be removed in an upcoming release.
/Users/b-long/Desktop/github/b-long/aid/.venv/lib/python3.10/site-packages/prefect/storage/docker.py:325: UserWarning: This Docker storage object has no `registry_url`, and will not be pushed.
  self._build_image(push=push)
[2022-09-20 20:15:21-0400] INFO - prefect.Docker | Building the flow's Docker storage...
Step 1/20 : FROM python:3.10-slim as base
 ---> d7971c18b18e
Step 2/20 : ENV PYTHONPATH=/workdir/
 ---> Using cache
 ---> 0fe42d41e412
Step 3/20 : RUN apt-get update && apt-get install -y gcc python3-dev git gcc g++ libblas-dev
 ---> Using cache
 ---> 557c34bb773c
Step 4/20 : RUN pip install --upgrade pip
 ---> Using cache
 ---> e84b680e5f03
Step 5/20 : RUN pip install poetry
 ---> Using cache
 ---> 81c419e11294
Step 6/20 : FROM base
 ---> 81c419e11294
Step 7/20 : RUN poetry config virtualenvs.create false
 ---> Using cache
 ---> 87f657fcfde8
Step 8/20 : RUN poetry config virtualenvs.prefer-active-python true
 ---> Using cache
 ---> 28d97928e2c6
Step 9/20 : RUN poetry config installer.no-binary :all:
 ---> Using cache
 ---> a7cbf854642c
Step 10/20 : WORKDIR /workdir/
 ---> Using cache
 ---> 75c23ec78585
Step 11/20 : COPY . /workdir/
 ---> 438599d92411
Step 12/20 : RUN poetry install --only main --no-root
 ---> Running in 6d12eeb517bf
Recreating virtualenv aid in /workdir/.venv
The virtual environment found in /workdir/.venv seems to be broken.

Installing dependencies from lock file
Package operations: 66 installs, 0 updates, 0 removals
  • Installing certifi (2022.6.15.1)
  • Installing charset-normalizer (2.1.1)
  • Installing frozenlist (1.3.1)
  • Installing idna (3.3)
  • Installing locket (1.0.0)
  • Installing multidict (6.0.2)
  • Installing pyasn1 (0.4.8)
  • Installing pyparsing (3.0.9)
  • Installing toolz (0.12.0)
  • Installing urllib3 (1.26.12)
  • Installing aiosignal (1.2.0)
  • Installing async-timeout (4.0.2)
  • Installing attrs (22.1.0)
  • Installing cachetools (5.2.0)
  • Installing cloudpickle (2.2.0)
  • Installing fsspec (2022.8.2)
  • Installing markupsafe (2.1.1)
  • Installing heapdict (1.0.1)
  • Installing oauthlib (3.2.1)
  • Installing packaging (21.3)
  • Installing partd (1.3.0)
  • Installing pyasn1-modules (0.2.8)
  • Installing pyyaml (6.0)
  • Installing requests (2.28.1)
  • Installing rsa (4.9)
  • Installing six (1.16.0)
  • Installing yarl (1.8.1)
  • Installing aiohttp (3.8.1)
  • Installing click (8.1.3)
  • Installing dask (2022.9.0)
  • Installing google-auth (2.11.0)
  • Installing iso8601 (1.0.2)
  • Installing jinja2 (3.1.2)
  • Installing msgpack (1.0.4)
  • Installing psutil (5.9.2)
  • Installing python-dateutil (2.8.2)
  • Installing python-json-logger (2.0.4)
  • Installing requests-oauthlib (1.3.1)
  • Installing sortedcontainers (2.4.0)
  • Installing tblib (1.7.0)
  • Installing tornado (6.1)
  • Installing typing-extensions (4.3.0)
  • Installing websocket-client (1.4.1)
  • Installing zict (2.2.0)
  • Installing distributed (2022.9.0)
  • Installing kopf (1.35.6)
  • Installing kubernetes (24.2.0)
  • Installing kubernetes-asyncio (24.2.2)
  • Installing marshmallow (3.17.1)
  • Installing pytzdata (2020.1)
  • Installing text-unidecode (1.3)
  • Installing croniter (1.3.7)
  • Installing dask-kubernetes (2022.7.0)
  • Installing docker (6.0.0)
  • Installing importlib-resources (5.9.0)
  • Installing marshmallow-oneofschema (3.0.1)
  • Installing mypy-extensions (0.4.3)
  • Installing numpy (1.23.3)
  • Installing pendulum (2.1.2)
  • Installing python-box (6.0.2)
  • Installing python-slugify (6.1.2)
  • Installing pytz (2022.2.1)
  • Installing tabulate (0.8.10)
  • Installing toml (0.10.2)
  • Installing pandas (1.4.4)
  • Installing prefect (1.3.1)
Removing intermediate container 6d12eeb517bf
 ---> 52c95d98195e
Step 13/20 : ENV PREFECT__USER_CONFIG_PATH='/opt/prefect/config.toml'
 ---> Running in 6f1f6d7fbe0a
Removing intermediate container 6f1f6d7fbe0a
 ---> e60cf49facc4
Step 14/20 : RUN pip install pip --upgrade
 ---> Running in 22114a0bade3
Requirement already satisfied: pip in /usr/local/lib/python3.10/site-packages (22.2.2)
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv

Removing intermediate container 22114a0bade3
 ---> 67a988c7da27
Step 15/20 : RUN pip show prefect || pip install git+https://github.com/PrefectHQ/prefect.git@1.3.1#egg=prefect[all_orchestration_extras]
 ---> Running in b67d24dbe470
WARNING: Package(s) not found: prefect

Collecting prefect[all_orchestration_extras]
  Cloning https://github.com/PrefectHQ/prefect.git (to revision 1.3.1) to /tmp/pip-install-m_3wcfye/prefect_b2b35895cb114e7eadd933b2884ac227
  Running command git clone --filter=blob:none --quiet https://github.com/PrefectHQ/prefect.git /tmp/pip-install-m_3wcfye/prefect_b2b35895cb114e7eadd933b2884ac227

  Running command git checkout -q 75a081da8d96d4a566ded48f33361008fd444877

  Resolved https://github.com/PrefectHQ/prefect.git to commit 75a081da8d96d4a566ded48f33361008fd444877
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Collecting marshmallow-oneofschema>=2.0.0b2
  Downloading marshmallow_oneofschema-3.0.1-py2.py3-none-any.whl (5.8 kB)
Requirement already satisfied: requests>=2.25 in /usr/local/lib/python3.10/site-packages (from prefect[all_orchestration_extras]) (2.28.1)
Collecting pendulum>=2.0.4
  Downloading pendulum-2.1.2.tar.gz (81 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 81.2/81.2 kB 1.5 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Collecting pytz>=2018.7
  Downloading pytz-2022.2.1-py2.py3-none-any.whl (500 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 500.6/500.6 kB 5.8 MB/s eta 0:00:00
Collecting marshmallow>=3.0.0b19
  Downloading marshmallow-3.18.0-py3-none-any.whl (48 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.8/48.8 kB 8.2 MB/s eta 0:00:00
Collecting dask>=2021.06.0
  Downloading dask-2022.9.1-py3-none-any.whl (1.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.1/1.1 MB 14.5 MB/s eta 0:00:00
Collecting toml>=0.9.4
  Downloading toml-0.10.2-py2.py3-none-any.whl (16 kB)
Collecting importlib-resources>=3.0.0
  Downloading importlib_resources-5.9.0-py3-none-any.whl (33 kB)
Collecting mypy-extensions>=0.4.0
  Downloading mypy_extensions-0.4.3-py2.py3-none-any.whl (4.5 kB)
Collecting croniter>=0.3.24
  Downloading croniter-1.3.7-py2.py3-none-any.whl (17 kB)
Collecting distributed>=2.17.0
  Downloading distributed-2022.9.1-py3-none-any.whl (903 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 903.8/903.8 kB 29.5 MB/s eta 0:00:00
Collecting pyyaml>=3.13
  Downloading PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (682 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 682.2/682.2 kB 36.7 MB/s eta 0:00:00
Requirement already satisfied: urllib3>=1.26.0 in /usr/local/lib/python3.10/site-packages (from prefect[all_orchestration_extras]) (1.26.12)
Collecting cloudpickle>=1.3.0
  Downloading cloudpickle-2.2.0-py3-none-any.whl (25 kB)
Collecting python-box>=5.1.0
  Downloading python_box-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.3 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.3/3.3 MB 40.6 MB/s eta 0:00:00
Requirement already satisfied: packaging>=20.0 in /usr/local/lib/python3.10/site-packages (from prefect[all_orchestration_extras]) (21.3)
Collecting python-dateutil>=2.7.0
  Downloading python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 247.7/247.7 kB 32.3 MB/s eta 0:00:00
Collecting click>=7.0
  Downloading click-8.1.3-py3-none-any.whl (96 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 96.6/96.6 kB 16.3 MB/s eta 0:00:00
Collecting python-slugify>=1.2.6
  Downloading python_slugify-6.1.2-py2.py3-none-any.whl (9.4 kB)
Requirement already satisfied: msgpack>=0.6.0 in /usr/local/lib/python3.10/site-packages (from prefect[all_orchestration_extras]) (1.0.4)
Collecting tabulate>=0.8.0
  Downloading tabulate-0.8.10-py3-none-any.whl (29 kB)
Collecting docker>=3.4.1
  Downloading docker-6.0.0-py3-none-any.whl (147 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 147.2/147.2 kB 28.3 MB/s eta 0:00:00
Requirement already satisfied: dulwich>=0.19.7 in /usr/local/lib/python3.10/site-packages (from prefect[all_orchestration_extras]) (0.20.46)
Collecting atlassian-python-api>=2.0.1
  Downloading atlassian-python-api-3.28.1.tar.gz (138 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 138.9/138.9 kB 31.1 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Collecting boto3>=1.9
  Downloading boto3-1.24.77-py3-none-any.whl (132 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 132.5/132.5 kB 24.9 MB/s eta 0:00:00
Collecting google-auth>=2.0
  Downloading google_auth-2.11.1-py2.py3-none-any.whl (167 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 167.1/167.1 kB 20.0 MB/s eta 0:00:00
Collecting google-cloud-secret-manager>=2.4.0
  Downloading google_cloud_secret_manager-2.12.4-py2.py3-none-any.whl (98 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 98.3/98.3 kB 18.6 MB/s eta 0:00:00
Collecting azure-identity>=1.7.0
  Downloading azure_identity-1.11.0-py3-none-any.whl (136 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 136.9/136.9 kB 21.5 MB/s eta 0:00:00
Collecting python-gitlab>=2.5.0
  Downloading python_gitlab-3.9.0-py3-none-any.whl (127 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 127.1/127.1 kB 30.2 MB/s eta 0:00:00
Collecting azure-storage-blob>=12.1.0
  Downloading azure_storage_blob-12.13.1-py3-none-any.whl (377 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 377.4/377.4 kB 30.0 MB/s eta 0:00:00
Collecting PyGithub>=1.51
  Downloading PyGithub-1.55-py3-none-any.whl (291 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 291.7/291.7 kB 45.3 MB/s eta 0:00:00
Collecting kubernetes>=9.0.0a1.0
  Downloading kubernetes-24.2.0-py2.py3-none-any.whl (1.5 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.5/1.5 MB 32.7 MB/s eta 0:00:00
Collecting google-cloud-storage>=1.13
  Downloading google_cloud_storage-2.5.0-py2.py3-none-any.whl (106 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 107.0/107.0 kB 20.0 MB/s eta 0:00:00
Collecting google-cloud-aiplatform>=1.4.0
  Downloading google_cloud_aiplatform-1.17.1-py2.py3-none-any.whl (2.3 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.3/2.3 MB 27.1 MB/s eta 0:00:00
Collecting deprecated
  Downloading Deprecated-1.2.13-py2.py3-none-any.whl (9.6 kB)
Requirement already satisfied: six in /usr/local/lib/python3.10/site-packages (from atlassian-python-api>=2.0.1->prefect[all_orchestration_extras]) (1.16.0)
Collecting requests-oauthlib
  Downloading requests_oauthlib-1.3.1-py2.py3-none-any.whl (23 kB)
Collecting oauthlib
  Downloading oauthlib-3.2.1-py3-none-any.whl (151 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 151.7/151.7 kB 30.2 MB/s eta 0:00:00
Collecting msal<2.0.0,>=1.12.0
  Downloading msal-1.18.0-py2.py3-none-any.whl (82 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 82.4/82.4 kB 7.5 MB/s eta 0:00:00
Requirement already satisfied: cryptography>=2.5 in /usr/local/lib/python3.10/site-packages (from azure-identity>=1.7.0->prefect[all_orchestration_extras]) (38.0.1)
Collecting msal-extensions<2.0.0,>=0.3.0
  Downloading msal_extensions-1.0.0-py2.py3-none-any.whl (19 kB)
Collecting azure-core<2.0.0,>=1.11.0
  Downloading azure_core-1.25.1-py3-none-any.whl (178 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 178.8/178.8 kB 35.1 MB/s eta 0:00:00
Collecting msrest>=0.6.21
  Downloading msrest-0.7.1-py3-none-any.whl (85 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 85.4/85.4 kB 19.5 MB/s eta 0:00:00
Collecting s3transfer<0.7.0,>=0.6.0
  Downloading s3transfer-0.6.0-py3-none-any.whl (79 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 79.6/79.6 kB 17.9 MB/s eta 0:00:00
Collecting botocore<1.28.0,>=1.27.77
  Downloading botocore-1.27.77-py3-none-any.whl (9.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 9.1/9.1 MB 49.0 MB/s eta 0:00:00
Collecting jmespath<2.0.0,>=0.7.1
  Downloading jmespath-1.0.1-py3-none-any.whl (20 kB)
Collecting fsspec>=0.6.0
  Downloading fsspec-2022.8.2-py3-none-any.whl (140 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 140.8/140.8 kB 27.6 MB/s eta 0:00:00
Collecting partd>=0.3.10
  Downloading partd-1.3.0-py3-none-any.whl (18 kB)
Collecting toolz>=0.8.2
  Downloading toolz-0.12.0-py3-none-any.whl (55 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 55.8/55.8 kB 10.6 MB/s eta 0:00:00
Collecting psutil>=5.0
  Downloading psutil-5.9.2-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (282 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 282.8/282.8 kB 35.3 MB/s eta 0:00:00
Collecting jinja2
  Downloading Jinja2-3.1.2-py3-none-any.whl (133 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 133.1/133.1 kB 20.9 MB/s eta 0:00:00
Collecting sortedcontainers!=2.0.0,!=2.0.1
  Downloading sortedcontainers-2.4.0-py2.py3-none-any.whl (29 kB)
Collecting zict>=0.1.3
  Downloading zict-2.2.0-py2.py3-none-any.whl (23 kB)
Collecting tornado<6.2,>=6.0.3
  Downloading tornado-6.1.tar.gz (497 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 497.4/497.4 kB 33.8 MB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Collecting locket>=1.0.0
  Downloading locket-1.0.0-py2.py3-none-any.whl (4.4 kB)
Collecting tblib>=1.6.0
  Downloading tblib-1.7.0-py2.py3-none-any.whl (12 kB)
Collecting websocket-client>=0.32.0
  Downloading websocket_client-1.4.1-py3-none-any.whl (55 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 55.0/55.0 kB 12.7 MB/s eta 0:00:00
Collecting rsa<5,>=3.1.4
  Downloading rsa-4.9-py3-none-any.whl (34 kB)
Collecting pyasn1-modules>=0.2.1
  Downloading pyasn1_modules-0.2.8-py2.py3-none-any.whl (155 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 155.3/155.3 kB 22.6 MB/s eta 0:00:00
Collecting cachetools<6.0,>=2.0.0
  Downloading cachetools-5.2.0-py3-none-any.whl (9.3 kB)
Collecting google-cloud-bigquery<3.0.0dev,>=1.15.0
  Downloading google_cloud_bigquery-2.34.4-py2.py3-none-any.whl (206 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 206.6/206.6 kB 40.9 MB/s eta 0:00:00
Collecting proto-plus<2.0.0dev,>=1.22.0
  Downloading proto_plus-1.22.1-py3-none-any.whl (47 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 47.9/47.9 kB 9.9 MB/s eta 0:00:00
Collecting google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,<3.0.0dev,>=1.32.0
  Downloading google_api_core-2.10.1-py3-none-any.whl (115 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 115.5/115.5 kB 26.3 MB/s eta 0:00:00
Collecting google-cloud-resource-manager<3.0.0dev,>=1.3.3
  Downloading google_cloud_resource_manager-1.6.1-py2.py3-none-any.whl (231 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 231.1/231.1 kB 38.1 MB/s eta 0:00:00
Collecting protobuf<5.0.0dev,>=3.19.0
  Downloading protobuf-4.21.6-cp37-abi3-manylinux2014_x86_64.whl (408 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 408.4/408.4 kB 39.8 MB/s eta 0:00:00
Collecting grpc-google-iam-v1<1.0.0dev,>=0.12.4
  Downloading grpc_google_iam_v1-0.12.4-py2.py3-none-any.whl (26 kB)
Collecting google-cloud-core<3.0dev,>=2.3.0
  Downloading google_cloud_core-2.3.2-py2.py3-none-any.whl (29 kB)
Collecting google-resumable-media>=2.3.2
  Downloading google_resumable_media-2.3.3-py2.py3-none-any.whl (76 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 76.9/76.9 kB 9.8 MB/s eta 0:00:00
Requirement already satisfied: certifi>=14.05.14 in /usr/local/lib/python3.10/site-packages (from kubernetes>=9.0.0a1.0->prefect[all_orchestration_extras]) (2022.9.14)
Requirement already satisfied: setuptools>=21.0.0 in /usr/local/lib/python3.10/site-packages (from kubernetes>=9.0.0a1.0->prefect[all_orchestration_extras]) (63.2.0)
Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /usr/local/lib/python3.10/site-packages (from packaging>=20.0->prefect[all_orchestration_extras]) (3.0.9)
Collecting pytzdata>=2020.1
  Downloading pytzdata-2020.1-py2.py3-none-any.whl (489 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 490.0/490.0 kB 45.0 MB/s eta 0:00:00
Collecting pyjwt>=2.0
  Downloading PyJWT-2.5.0-py3-none-any.whl (20 kB)
Collecting pynacl>=1.4.0
  Downloading PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl (856 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 856.7/856.7 kB 42.7 MB/s eta 0:00:00
Requirement already satisfied: requests-toolbelt>=0.9.1 in /usr/local/lib/python3.10/site-packages (from python-gitlab>=2.5.0->prefect[all_orchestration_extras]) (0.9.1)
Collecting text-unidecode>=1.3
  Downloading text_unidecode-1.3-py2.py3-none-any.whl (78 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 78.2/78.2 kB 20.2 MB/s eta 0:00:00
Requirement already satisfied: charset-normalizer<3,>=2 in /usr/local/lib/python3.10/site-packages (from requests>=2.25->prefect[all_orchestration_extras]) (2.1.1)
Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/site-packages (from requests>=2.25->prefect[all_orchestration_extras]) (3.4)
Collecting typing-extensions>=4.0.1
  Using cached typing_extensions-4.3.0-py3-none-any.whl (25 kB)
Requirement already satisfied: cffi>=1.12 in /usr/local/lib/python3.10/site-packages (from cryptography>=2.5->azure-identity>=1.7.0->prefect[all_orchestration_extras]) (1.15.1)
Collecting googleapis-common-protos<2.0dev,>=1.56.2
  Downloading googleapis_common_protos-1.56.4-py2.py3-none-any.whl (211 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 211.7/211.7 kB 22.9 MB/s eta 0:00:00
Collecting grpcio-status<2.0dev,>=1.33.2
  Downloading grpcio_status-1.48.1-py3-none-any.whl (14 kB)
Collecting grpcio<2.0dev,>=1.33.2
  Downloading grpcio-1.48.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (4.6 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.6/4.6 MB 34.1 MB/s eta 0:00:00
Collecting protobuf<5.0.0dev,>=3.19.0
  Downloading protobuf-3.20.2-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (1.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.1/1.1 MB 33.2 MB/s eta 0:00:00
Collecting google-crc32c<2.0dev,>=1.0
  Downloading google_crc32c-1.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (32 kB)
Collecting portalocker<3,>=1.0
  Downloading portalocker-2.5.1-py2.py3-none-any.whl (15 kB)
Collecting isodate>=0.6.0
  Downloading isodate-0.6.1-py2.py3-none-any.whl (41 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 41.7/41.7 kB 10.1 MB/s eta 0:00:00
Collecting pyasn1<0.5.0,>=0.4.6
  Downloading pyasn1-0.4.8-py2.py3-none-any.whl (77 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 77.1/77.1 kB 14.2 MB/s eta 0:00:00
Collecting heapdict
  Downloading HeapDict-1.0.1-py3-none-any.whl (3.9 kB)
Collecting wrapt<2,>=1.10
  Downloading wrapt-1.14.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (77 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 77.9/77.9 kB 12.5 MB/s eta 0:00:00
Collecting MarkupSafe>=2.0
  Downloading MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (25 kB)
Requirement already satisfied: pycparser in /usr/local/lib/python3.10/site-packages (from cffi>=1.12->cryptography>=2.5->azure-identity>=1.7.0->prefect[all_orchestration_extras]) (2.21)
Collecting types-cryptography>=3.3.21
  Downloading types_cryptography-3.3.23-py3-none-any.whl (30 kB)
Building wheels for collected packages: atlassian-python-api, pendulum, prefect, tornado
  Building wheel for atlassian-python-api (pyproject.toml): started
  Building wheel for atlassian-python-api (pyproject.toml): finished with status 'done'
  Created wheel for atlassian-python-api: filename=atlassian_python_api-3.28.1-py3-none-any.whl size=141452 sha256=71a3a336c563c617045b796da5213df6d1e0f69af632a82b150fa070630717a1
  Stored in directory: /root/.cache/pip/wheels/09/aa/d4/d255db165081f55cac34945d4971096579ad9b18106f583191
  Building wheel for pendulum (pyproject.toml): started
  Building wheel for pendulum (pyproject.toml): finished with status 'done'
  Created wheel for pendulum: filename=pendulum-2.1.2-cp310-cp310-manylinux_2_31_x86_64.whl size=126342 sha256=6a4da417f7cd5eff3ed50d149c205ea043209435b26c10057a8c65050081277a
  Stored in directory: /root/.cache/pip/wheels/2e/41/ed/f113e4c9dc10f6c846d69f412e9cd9aa429960a3e2e485a4f9
  Building wheel for prefect (pyproject.toml): started
  Building wheel for prefect (pyproject.toml): finished with status 'done'
  Created wheel for prefect: filename=prefect-1.3.1-py3-none-any.whl size=604652 sha256=7141ea0e7aed6da874ae058f63051b9fc600935bb35aca0b13110321bcdfa28b
  Stored in directory: /tmp/pip-ephem-wheel-cache-xoe0cy5y/wheels/f6/02/c5/08ad6aece23eb9d88541a3178b2e3e0819ef6ede393455d61e
  Building wheel for tornado (setup.py): started
  Building wheel for tornado (setup.py): finished with status 'done'
  Created wheel for tornado: filename=tornado-6.1-cp310-cp310-linux_x86_64.whl size=416502 sha256=89bb4e6af5e2dbc6dc5162bb651ada86c3dab0a7952efd3d6435120ae7fe97b0
  Stored in directory: /root/.cache/pip/wheels/80/32/8d/21cf0fa6ee4e083f6530e5b83dfdfa9489a3890d320803f4c7
Successfully built atlassian-python-api pendulum prefect tornado
Installing collected packages: types-cryptography, text-unidecode, sortedcontainers, pytz, pyasn1, mypy-extensions, heapdict, zict, wrapt, websocket-client, typing-extensions, tornado, toolz, toml, tblib, tabulate, rsa, pyyaml, pytzdata, python-slugify, python-dateutil, python-box, pyjwt, pyasn1-modules, psutil, protobuf, portalocker, oauthlib, MarkupSafe, locket, jmespath, isodate, importlib-resources, grpcio, google-crc32c, fsspec, cloudpickle, click, cachetools, requests-oauthlib, pynacl, proto-plus, pendulum, partd, marshmallow, jinja2, googleapis-common-protos, google-resumable-media, google-auth, docker, deprecated, croniter, botocore, azure-core, s3transfer, python-gitlab, PyGithub, msrest, marshmallow-oneofschema, kubernetes, grpcio-status, google-api-core, dask, atlassian-python-api, msal, grpc-google-iam-v1, google-cloud-core, distributed, boto3, azure-storage-blob, prefect, msal-extensions, google-cloud-storage, google-cloud-secret-manager, google-cloud-resource-manager, google-cloud-bigquery, google-cloud-aiplatform, azure-identity
Successfully installed MarkupSafe-2.1.1 PyGithub-1.55 atlassian-python-api-3.28.1 azure-core-1.25.1 azure-identity-1.11.0 azure-storage-blob-12.13.1 boto3-1.24.77 botocore-1.27.77 cachetools-5.2.0 click-8.1.3 cloudpickle-2.2.0 croniter-1.3.7 dask-2022.9.1 deprecated-1.2.13 distributed-2022.9.1 docker-6.0.0 fsspec-2022.8.2 google-api-core-2.10.1 google-auth-2.11.1 google-cloud-aiplatform-1.17.1 google-cloud-bigquery-2.34.4 google-cloud-core-2.3.2 google-cloud-resource-manager-1.6.1 google-cloud-secret-manager-2.12.4 google-cloud-storage-2.5.0 google-crc32c-1.5.0 google-resumable-media-2.3.3 googleapis-common-protos-1.56.4 grpc-google-iam-v1-0.12.4 grpcio-1.48.1 grpcio-status-1.48.1 heapdict-1.0.1 importlib-resources-5.9.0 isodate-0.6.1 jinja2-3.1.2 jmespath-1.0.1 kubernetes-24.2.0 locket-1.0.0 marshmallow-3.18.0 marshmallow-oneofschema-3.0.1 msal-1.18.0 msal-extensions-1.0.0 msrest-0.7.1 mypy-extensions-0.4.3 oauthlib-3.2.1 partd-1.3.0 pendulum-2.1.2 portalocker-2.5.1 prefect-1.3.1 proto-plus-1.22.1 protobuf-3.20.2 psutil-5.9.2 pyasn1-0.4.8 pyasn1-modules-0.2.8 pyjwt-2.5.0 pynacl-1.5.0 python-box-6.0.2 python-dateutil-2.8.2 python-gitlab-3.9.0 python-slugify-6.1.2 pytz-2022.2.1 pytzdata-2020.1 pyyaml-6.0 requests-oauthlib-1.3.1 rsa-4.9 s3transfer-0.6.0 sortedcontainers-2.4.0 tabulate-0.8.10 tblib-1.7.0 text-unidecode-1.3 toml-0.10.2 toolz-0.12.0 tornado-6.1 types-cryptography-3.3.23 typing-extensions-4.3.0 websocket-client-1.4.1 wrapt-1.14.1 zict-2.2.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv

Removing intermediate container b67d24dbe470
 ---> 9bed13721b58
Step 16/20 : RUN pip install 'wheel'
 ---> Running in fa47a6c3d62a
Requirement already satisfied: wheel in /usr/local/lib/python3.10/site-packages (0.37.1)
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv

Removing intermediate container fa47a6c3d62a
 ---> 8bc7dc204831
Step 17/20 : RUN mkdir -p /opt/prefect/
 ---> Running in 0cb75aff6f33
Removing intermediate container 0cb75aff6f33
 ---> 76b27c443420
Step 18/20 : COPY ./tmpvzcwmqzh/basic-add-flow.flow /opt/prefect/flows/basic-add-flow.prefect
 ---> cb28188fd5fd
Step 19/20 : COPY ./tmpvzcwmqzh/healthcheck.py /opt/prefect/healthcheck.py
 ---> 1be4a7f34066
Step 20/20 : RUN python /opt/prefect/healthcheck.py '["/opt/prefect/flows/basic-add-flow.prefect"]' '(3, 10)'
 ---> Running in 8eb4bfac9ba2
Beginning health checks...
System Version check: OK
Cloudpickle serialization check: OK
Result check: OK
All health checks passed.
Removing intermediate container 8eb4bfac9ba2
 ---> 27d18d97d748
Successfully built 27d18d97d748
Successfully tagged basic-add-flow:basic-add-flow
Flow URL: http://localhost:8080/aid-tenant/flow/afd95d87-ba5b-4048-b547-9eba85e4d715
 └── ID: 41c66078-27d4-4112-bdf6-1b717318b0af
 └── Project: aid-tenant
 └── Labels: []
```
